### PR TITLE
ghpages

### DIFF
--- a/.github/workflows/ghpdoxy.yaml
+++ b/.github/workflows/ghpdoxy.yaml
@@ -1,0 +1,14 @@
+name: Doxygen GitHub Pages Deploy Action
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DenverCoder1/doxygen-github-pages-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Publish github pages from doxygen.. Obviously in the future you would want to use something else. maybe hugo? Ala: https://github.com/arran4/blog for an actual website but this should be good enough for now.

Also completely untested. You will also need to enable github pages on the branch: `gh-pages` In settings for this to work..

Then accessible via:
https://DMHC.github.io/Linwarrior3D/
Once enabled.